### PR TITLE
feat: cdn is_allowed_http_methods_locked

### DIFF
--- a/proto/v1/cdn.proto
+++ b/proto/v1/cdn.proto
@@ -683,6 +683,9 @@ message Settings {
     // Параметр настраивает доступ к контенту с токенизированными URL-адресами, сгенерированными с помощью алгоритма MD5
     TokenizedUrlSecureKey tokenized_url_secure_key = 12;
 
+    // Возможность менять настройку AllowedHttpMethods
+    bool is_allowed_http_methods_locked = 21;
+
     // Параметр задаёт список разрешённых HTTP-методов для контента CDN
     AllowedHttpMethods allowed_http_methods = 13;
 


### PR DESCRIPTION
Добавлен флаг is_allowed_http_methods_locked указывающий возможность менять настройку allowed_http_methods